### PR TITLE
Feature: Download CSV

### DIFF
--- a/dune_client/api/execution.py
+++ b/dune_client/api/execution.py
@@ -83,8 +83,6 @@ class ExecutionAPI(BaseRouter):
         if you need metadata information use get_results() or get_status()
         """
         route = f"/execution/{job_id}/results/csv"
-        url = self._route_url(f"/execution/{job_id}/results/csv")
-        self.logger.debug(f"GET CSV received input url={url}")
         response = self._get(route=route, raw=True)
         response.raise_for_status()
         return ExecutionResultCSV(data=BytesIO(response.content))

--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -3,6 +3,7 @@ Extended functionality for the ExecutionAPI
 """
 
 import time
+from io import BytesIO
 from typing import Union, Optional, Any
 
 from deprecated import deprecated
@@ -15,7 +16,7 @@ from dune_client.models import (
     QueryFailed,
     ExecutionResultCSV,
 )
-from dune_client.query import QueryBase
+from dune_client.query import QueryBase, parse_query_object_or_id
 
 
 class ExtendedAPI(ExecutionAPI):
@@ -78,19 +79,11 @@ class ExtendedAPI(ExecutionAPI):
         GET the latest results for a query_id without re-executing the query
         (doesn't use execution credits)
 
-        :param query: :class:`Query` object OR query id as string | int
+        :param query: :class:`Query` object OR query id as string or int
 
-        https://dune.com/docs/api/api-reference/latest_results/
+            https://dune.com/docs/api/api-reference/get-results/latest-results
         """
-        if isinstance(query, QueryBase):
-            params = {
-                f"params.{p.key}": p.to_dict()["value"] for p in query.parameters()
-            }
-            query_id = query.query_id
-        else:
-            params = None
-            query_id = int(query)
-
+        params, query_id = parse_query_object_or_id(query)
         response_json = self._get(
             route=f"/query/{query_id}/results",
             params=params,
@@ -100,6 +93,21 @@ class ExtendedAPI(ExecutionAPI):
         except KeyError as err:
             raise DuneError(response_json, "ResultsResponse", err) from err
 
+    def download_csv(self, query: Union[QueryBase, str, int]) -> ExecutionResultCSV:
+        """
+        Almost like an alias for `get_latest_result` but for the csv endpoint.
+        https://dune.com/docs/api/api-reference/get-results/latest-results
+        """
+        params, query_id = parse_query_object_or_id(query)
+        response = self._get(
+            route=f"/query/{query_id}/results/csv", params=params, raw=True
+        )
+        response.raise_for_status()
+        return ExecutionResultCSV(data=BytesIO(response.content))
+
+    ############################
+    # Plus Subscription Features
+    ############################
     def upload_csv(self, table_name: str, data: str, description: str = "") -> bool:
         """
         https://dune.com/docs/api/api-reference/upload-data/?h=data+upload#endpoint

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -28,7 +28,7 @@ from dune_client.models import (
     ExecutionState,
 )
 
-from dune_client.query import QueryBase
+from dune_client.query import QueryBase, parse_query_object_or_id
 
 
 # pylint: disable=duplicate-code
@@ -181,15 +181,7 @@ class AsyncDuneClient(BaseDuneClient):
 
         https://dune.com/docs/api/api-reference/latest_results/
         """
-        if isinstance(query, QueryBase):
-            params = {
-                f"params.{p.key}": p.to_dict()["value"] for p in query.parameters()
-            }
-            query_id = query.query_id
-        else:
-            params = None
-            query_id = int(query)
-
+        params, query_id = parse_query_object_or_id(query)
         response_json = await self._get(
             route=f"/query/{query_id}/results",
             params=params,

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -183,7 +183,7 @@ class ExecutionResultCSV:
     Representation of a raw `result` in CSV format
     this payload can be passed directly to
         csv.reader(data) or
-        pandas.from_csv(data)
+        pandas.read_csv(data)
     """
 
     data: BytesIO  # includes all CSV rows, including the header row.

--- a/dune_client/query.py
+++ b/dune_client/query.py
@@ -9,6 +9,22 @@ from typing import Optional, List, Dict, Union, Any
 from dune_client.types import QueryParameter
 
 
+def parse_query_object_or_id(
+    query: Union[QueryBase, str, int],
+) -> tuple[dict[str, str] | None, int]:
+    """
+    Users are allowed to pass QueryBase or ID into some functions.
+    This method handles both scenarios, returning a pair of the form (params, query_id)
+    """
+    if isinstance(query, QueryBase):
+        params = {f"params.{p.key}": p.to_dict()["value"] for p in query.parameters()}
+        query_id = query.query_id
+    else:
+        params = None
+        query_id = int(query)
+    return params, query_id
+
+
 @dataclass
 class QueryBase:
     """Basic data structure constituting a Dune Analytics Query."""

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,11 +1,11 @@
 import unittest
 from datetime import datetime
 
-from dune_client.query import QueryBase
+from dune_client.query import QueryBase, parse_query_object_or_id
 from dune_client.types import QueryParameter
 
 
-class TestQueryMonitor(unittest.TestCase):
+class TestQueryBase(unittest.TestCase):
     def setUp(self) -> None:
         self.date = datetime(year=1985, month=3, day=10)
         self.query_params = [
@@ -59,6 +59,30 @@ class TestQueryMonitor(unittest.TestCase):
         query1 = QueryBase(query_id=0)
         query2 = QueryBase(query_id=1, params=[QueryParameter.number_type("num", 1)])
         self.assertNotEqual(hash(query1), hash(query2))
+
+    def test_parse_object_or_id(self):
+        expected_params = {
+            "params.Date": "2021-01-01 12:34:56",
+            "params.Enum": "option1",
+            "params.Number": "12",
+            "params.Text": "plain text",
+        }
+        expected_query_id = self.query.query_id
+        # Query Object
+        self.assertEqual(
+            parse_query_object_or_id(self.query), (expected_params, expected_query_id)
+        )
+        # Query ID (integer)
+        expected_params = None
+        self.assertEqual(
+            parse_query_object_or_id(self.query.query_id),
+            (expected_params, expected_query_id),
+        )
+        # Query ID (string)
+        self.assertEqual(
+            parse_query_object_or_id(str(self.query.query_id)),
+            (expected_params, expected_query_id),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This method is similar to that of `get_latest_results`except that it returns in CSV format as outlined here: https://dune.com/docs/api/api-reference/get-results/latest-results/


I noticed that the docs don't give example responses of the csv route.

A few things were updated here (url to api docs on `get_latest_results`).

We created a utility function to avoid tripling the same code block that handles query objects or types. Functionality is now unit tested.

Closes #66 

cc @TheEdgeOfRage & @diegoximenes for additional review.