### PR TITLE
[Premium Feature] run_sql

### DIFF
--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -125,9 +125,9 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
         except KeyError as err:
             raise DuneError(response_json, "UploadCsvResponse", err) from err
 
-    ##################
-    # Premium Features
-    ##################
+    ##############################################################################################
+    # Premium Features: these features use APIs that are only available on paid subscription plans
+    ##############################################################################################
 
     def run_sql(
         self,

--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -18,6 +18,7 @@ from dune_client.models import (
     ExecutionResultCSV,
 )
 from dune_client.query import QueryBase, parse_query_object_or_id
+from dune_client.types import QueryParameter
 
 
 class ExtendedAPI(ExecutionAPI, QueryAPI):

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -4,10 +4,9 @@ Framework built on Dune's API Documentation
 https://duneanalytics.notion.site/API-Documentation-1b93d16e0fa941398e15047f643e003a
 """
 from dune_client.api.extensions import ExtendedAPI
-from dune_client.api.query import QueryAPI
 
 
-class DuneClient(QueryAPI, ExtendedAPI):
+class DuneClient(ExtendedAPI):
     """
     An interface for Dune API with a few convenience methods
     combining the use of endpoints (e.g. run_query)
@@ -16,13 +15,14 @@ class DuneClient(QueryAPI, ExtendedAPI):
 
         DuneClient
         |
-        |--- QueryAPI(BaseRouter)
-        |       - Contains CRUD Operations on Queries
-        |
         |--- ExtendedAPI
-                | - Contains higher level methods for higher productivity
-                |       (things like `run_query`, `run_query_csv`, etc..)
+                |   - Contains compositions of execution methods like `run_query`
+                |               (things like `run_query`, `run_query_csv`, etc..)
+                |   - make use of both Execution and Query APIs
                 |
                 |--- ExecutionAPI(BaseRouter)
-                        - Contains query execution and result related methods.
+                |        - Contains query execution methods.
+                |
+                |--- QueryAPI(BaseRouter)
+                |       - Contains CRUD Operations on Queries
     """

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -231,6 +231,17 @@ class TestCRUDOps(unittest.TestCase):
         self.assertEqual(self.client.archive_query(self.existing_query_id), True)
         self.assertEqual(self.client.unarchive_query(self.existing_query_id), False)
 
+    @unittest.skip("Works fine, but creates too many queries!")
+    def test_run_sql(self):
+        query_sql = "select 85"
+        results = self.client.run_sql(query_sql)
+        self.assertEqual(results.get_rows(), [{"_col0": 85}])
+
+        # The default functionality is meant to create a private query and then archive it.
+        query = self.client.get_query(results.query_id)
+        self.assertTrue(query.meta.is_archived)
+        self.assertTrue(query.meta.is_private)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #77 

Adds run_sql method which creates a query, executes, gets results and optionally archives the query (by default).

# Test Plan

This can't be tested with any API key that I have. But the test is there (skipped) and pretty straightforward to follow. Given that all the other routes are tested, it should be fine.

cc @TheEdgeOfRage & @diegoximenes for additional review.