### PR TITLE
Update QueryFailed error to include failure info.

### DIFF
--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -249,6 +249,6 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
             status = self.get_execution_status(job_id)
         if status.state == ExecutionState.FAILED:
             self.logger.error(status)
-            raise QueryFailed(f"{status}. Perhaps your query took too long to run!")
+            raise QueryFailed(f"Error data: {status.error}")
 
         return job_id

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -225,7 +225,7 @@ class AsyncDuneClient(BaseDuneClient):
             status = await self.get_status(job_id)
         if status.state == ExecutionState.FAILED:
             self.logger.error(status)
-            raise QueryFailed(f"{status}. Perhaps your query took too long to run!")
+            raise QueryFailed(f"Error data: {status.error}")
 
         return job_id
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -123,6 +123,7 @@ eth_traces,4474223
             times=TimeData.from_dict(self.status_response_data),
             result_metadata=None,
             queue_position=None,
+            error=None
         )
         self.assertEqual(
             expected, ExecutionStatusResponse.from_dict(self.status_response_data)
@@ -160,6 +161,7 @@ eth_traces,4474223
                 times=TimeData.from_dict(self.status_response_data),
                 result_metadata=ResultMetadata.from_dict(self.result_metadata_data),
                 queue_position=None,
+                error=None
             ),
             ExecutionStatusResponse.from_dict(self.status_response_data_completed),
         )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -123,7 +123,7 @@ eth_traces,4474223
             times=TimeData.from_dict(self.status_response_data),
             result_metadata=None,
             queue_position=None,
-            error=None
+            error=None,
         )
         self.assertEqual(
             expected, ExecutionStatusResponse.from_dict(self.status_response_data)
@@ -161,7 +161,7 @@ eth_traces,4474223
                 times=TimeData.from_dict(self.status_response_data),
                 result_metadata=ResultMetadata.from_dict(self.result_metadata_data),
                 queue_position=None,
-                error=None
+                error=None,
             ),
             ExecutionStatusResponse.from_dict(self.status_response_data_completed),
         )


### PR DESCRIPTION
When attempting to query a parameterized address with invalid string data we get error responses like:

```
export JOB_ID=01HBJFT6X600Z00VAJQFA9HQ5N
➜  ~ curl -X GET "https://api.dune.com/api/v1/execution/${JOB_ID}/results" -H x-dune-api-key:${DUNE_API_KEY}
```

```
{
  "execution_id": "01HBJFT6X600Z00VAJQFA9HQ5N",
  "query_id": 1416166,
  "state": "QUERY_STATE_FAILED",
  "submitted_at": "2023-09-30T07:28:27.558928Z",
  "expires_at": "2023-12-29T07:28:27.751448Z",
  "execution_started_at": "2023-09-30T07:28:27.564121Z",
  "execution_ended_at": "2023-09-30T07:28:27.751447Z",
  "error": {
    "type": "FAILED_TYPE_EXECUTION_FAILED",
    "message": "line 24:13: Binary literal can only contain hexadecimal digits at line 24, position 13 [Execution ID: 01HBJFT6X600Z00VAJQFA9HQ5N]",
    "metadata": {
      "line": 24,
      "column": 13
    }
  }
}
```

Which contain clear error message. This was not an issue before when using spark because spark used strings for binary data. 

This PR improves the error notification by actually returning the error.