### PR TITLE
PRO-211: Add support for is_private in upload_csv

### DIFF
--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -133,13 +133,20 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
     ############################
     # Plus Subscription Features
     ############################
-    def upload_csv(self, table_name: str, data: str, description: str = "") -> bool:
+    def upload_csv(
+        self,
+        table_name: str,
+        data: str,
+        description: str = "",
+        is_private: bool = False,
+    ) -> bool:
         """
         https://dune.com/docs/api/api-reference/upload-data/?h=data+upload#endpoint
         The write API allows you to upload any .csv file into Dune. The only limitations are:
 
         - File has to be < 200 MB
         - Column names in the table can't start with a special character or digits.
+        - Private uploads require a Premium subscription.
 
         Below are the specifics of how to work with the API.
         """
@@ -149,6 +156,7 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
                 "table_name": table_name,
                 "description": description,
                 "data": data,
+                "is_private": is_private,
             },
         )
         try:


### PR DESCRIPTION
As per https://github.com/duneanalytics/docs/pull/399 , the Dune Upload API now supports uploading private datasets. With this commit, we add this functionality to the upload_csv function.

I recognize that this functionality gets inside the "Plus Subscription" section even though it is premium. I decided that this was the best option and cleaner than creating a `upload_csv_private` function.

Closes #97.