### PR TITLE
relax the requirements on Deprecated package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@ name = dune_client
 description = A simple framework for interacting with Dune Analytics official API service.
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8
-url = https://github.com/cowprotocol/dune-client
-author = Benjamin H. Smith
+url = https://github.com/duneanalytics/dune-client
+author = Benjamin H. Smith & Dune Analytics
 author_email = ben@cow.fi
 license = Apache License Version 2.0
 license_files = LICENSE
@@ -13,7 +13,7 @@ classifiers =
   License :: OSI Approved :: Apache Software License
   Operating System :: OS Independent
 project_urls =
-  Tracker = https://github.com/cowprotocol/dune-client/issues
+  Tracker = https://github.com/duneanalytics/dune-client/issues
 
 [options]
 zip_safe = False
@@ -29,7 +29,7 @@ install_requires =
   python-dateutil>=2.8.2
   requests>=2.28.1
   ndjson>=0.3.1
-  Deprecated>=1.2.14
+  Deprecated>=1.2.0
 python_requires = >=3.8
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
this avoids an existing packaging dependency conflict with Hex.


"The problem with Hex and dune-client is a conflict with a library called Deprecated. The dune-client needs “Deprecated>=1.2.14”, but some packages from Hex need “Deprecated>=1.2.13".
