### PR TITLE
Add ping frequency param to run_sql

### DIFF
--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -196,6 +196,7 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
         is_private: bool = True,
         archive_after: bool = True,
         performance: Optional[str] = None,
+        ping_frequency: int = POLL_FREQUENCY_SECONDS,
         name: str = "API Query",
     ) -> ResultsResponse:
         """
@@ -205,7 +206,7 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
         Requires premium subscription!
         """
         query = self.create_query(name, query_sql, params, is_private)
-        results = self.run_query(query=query.base, performance=performance)
+        results = self.run_query(query=query.base, performance=performance, ping_frequency=ping_frequency)
         if archive_after:
             self.archive_query(query.base.query_id)
         return results


### PR DESCRIPTION
Super small PR here, and my first to the Dune-client.

I've been using the DuneAPI on team-AI and when we do a `run_sql` on a query I know will take some time I'd like to be able to select a custom polling interval so I don't get spammed with polling updates.