### PR TITLE
Introduce fix to archive failed queries on run_sql call

### DIFF
--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -253,11 +253,16 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
         Requires Plus subscription!
         """
         query = self.create_query(name, query_sql, params, is_private)
-        results = self.run_query(
-            query=query.base, performance=performance, ping_frequency=ping_frequency
-        )
-        if archive_after:
-            self.archive_query(query.base.query_id)
+        try:
+            results = self.run_query(
+                query=query.base, performance=performance, ping_frequency=ping_frequency
+            )
+            if archive_after:
+                self.archive_query(query.base.query_id)
+        except QueryFailed as exc:
+            if archive_after:
+                self.archive_query(query.base.query_id)
+            raise exc
         return results
 
     ######################

--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -257,12 +257,9 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
             results = self.run_query(
                 query=query.base, performance=performance, ping_frequency=ping_frequency
             )
+        finally:
             if archive_after:
                 self.archive_query(query.base.query_id)
-        except QueryFailed as exc:
-            if archive_after:
-                self.archive_query(query.base.query_id)
-            raise exc
         return results
 
     ######################


### PR DESCRIPTION
Hey hey!

I reported it on Slack, but basically I ran into a case where when using the `run_sql` query call, if the query fails we do not archive it. This resulted in me creating a bunch of broken queries and hitting the "private query limit" on the Dune account.

I've tried to introduce a simple fix here, but not 100% sure if this might be present elsewhere in the code.

🚀 keep up the amazing work