### PR TITLE
fixup: Set a limit to 1 instead of 0 when retrieving query results metadata

### DIFF
--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -189,10 +189,10 @@ class ExtendedAPI(ExecutionAPI, QueryAPI):
 
         params, query_id = parse_query_object_or_id(query)
 
-        # Only fetch the metadata first to determine if the result is fresh enough
+        # Only fetch 1 row to get metadata first to determine if the result is fresh enough
         if params is None:
             params = {}
-        params["limit"] = 0
+        params["limit"] = 1
 
         response_json = self._get(
             route=f"/query/{query_id}/results",


### PR DESCRIPTION
This change is needed because we are enforcing that the limit is non-zero on the API at the moment.