### PR TITLE
Lower min requests version to allow for compatibility with hex

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,10 +1,10 @@
 aiohttp>=3.8.5
 types-python-dateutil>=2.8.19.14
 types-PyYAML>=6.0.12.11
-types-requests>=2.31.0.2
+types-requests>=2.28.0
 types-setuptools>=68.2.0.0
 python-dateutil>=2.8.2
-requests>=2.31.0
+requests>=2.28.0
 ndjson>=0.3.1
 Deprecated>=1.2.14
 types-Deprecated==1.2.9.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,11 @@ install_requires =
   aiohttp>=3.8.3
   types-python-dateutil>=2.8.19
   types-PyYAML>=6.0.11
-  types-requests>=2.28.9
+  types-requests>=2.28.0
   types-Deprecated>=1.2.9.3
   types-setuptools>=68.2.0.0
   python-dateutil>=2.8.2
-  requests>=2.28.1
+  requests>=2.28.0
   ndjson>=0.3.1
   Deprecated>=1.2.0
 python_requires = >=3.8


### PR DESCRIPTION
Hex has 2.28.0 preinstalled, which causes dune_client to fail since we require 2.28.1. I don't think that we strictly need 2.28.1, so I'm relaxing the version constraint a bit