### PR TITLE
Updated /insert unit tests expected results

### DIFF
--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -277,7 +277,7 @@ class TestDuneClient(unittest.TestCase):
                     data=data,
                     content_type="text/csv",
                 ),
-                {'rows_written': 1},
+                {"rows_written": 1},
             )
 
     @unittest.skip("This is a plus subscription endpoint.")
@@ -293,7 +293,7 @@ class TestDuneClient(unittest.TestCase):
                     data=data,
                     content_type="application/x-ndjson",
                 ),
-                {'rows_written': 1},
+                {"rows_written": 1},
             )
 
     def test_download_csv_with_pagination(self):

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -277,7 +277,7 @@ class TestDuneClient(unittest.TestCase):
                     data=data,
                     content_type="text/csv",
                 ),
-                None,
+                {'rows_written': 1},
             )
 
     @unittest.skip("This is a plus subscription endpoint.")
@@ -293,7 +293,7 @@ class TestDuneClient(unittest.TestCase):
                     data=data,
                     content_type="application/x-ndjson",
                 ),
-                None,
+                {'rows_written': 1},
             )
 
     def test_download_csv_with_pagination(self):


### PR DESCRIPTION
Response of the `/insert` table endpoint change from `None` to `{'rows_written': X}`.
This update reflects that in the tests.