### PR TITLE
Return Types on Create and Insert Table

### DIFF
--- a/dune_client/api/table.py
+++ b/dune_client/api/table.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import List, Dict, IO
 
 from dune_client.api.base import BaseRouter
-from dune_client.models import DuneError, InsertTableResult, CreateTableResponse
+from dune_client.models import DuneError, InsertTableResult, CreateTableResult
 
 
 class TableAPI(BaseRouter):
@@ -54,7 +54,7 @@ class TableAPI(BaseRouter):
         schema: List[Dict[str, str]],
         description: str = "",
         is_private: bool = False,
-    ) -> CreateTableResponse:
+    ) -> CreateTableResult:
         """
         https://docs.dune.com/api-reference/tables/endpoint/create
         The create table endpoint allows you to create an empty table
@@ -76,7 +76,7 @@ class TableAPI(BaseRouter):
             },
         )
 
-        return CreateTableResponse.from_dict(result_json)
+        return CreateTableResult.from_dict(result_json)
 
     def insert_table(
         self,

--- a/dune_client/api/table.py
+++ b/dune_client/api/table.py
@@ -4,10 +4,10 @@ create and insert data into Dune.
 """
 
 from __future__ import annotations
-from typing import List, Dict, Any, IO
+from typing import List, Dict, IO
 
 from dune_client.api.base import BaseRouter
-from dune_client.models import DuneError
+from dune_client.models import DuneError, InsertTableResult, CreateTableResponse
 
 
 class TableAPI(BaseRouter):
@@ -54,7 +54,7 @@ class TableAPI(BaseRouter):
         schema: List[Dict[str, str]],
         description: str = "",
         is_private: bool = False,
-    ) -> Any:
+    ) -> CreateTableResponse:
         """
         https://docs.dune.com/api-reference/tables/endpoint/create
         The create table endpoint allows you to create an empty table
@@ -65,7 +65,7 @@ class TableAPI(BaseRouter):
         - Column names in the table can’t start with a special character or a digit.
         """
 
-        return self._post(
+        result_json = self._post(
             route="/table/create",
             params={
                 "namespace": namespace,
@@ -76,13 +76,15 @@ class TableAPI(BaseRouter):
             },
         )
 
+        return CreateTableResponse.from_dict(result_json)
+
     def insert_table(
         self,
         namespace: str,
         table_name: str,
         data: IO[bytes],
         content_type: str,
-    ) -> Any:
+    ) -> InsertTableResult:
         """
         https://docs.dune.com/api-reference/tables/endpoint/insert
         The insert table endpoint allows you to insert data into an existing table in Dune.
@@ -92,8 +94,10 @@ class TableAPI(BaseRouter):
         - The file has to have the same schema as the table
         """
 
-        return self._post(
+        result_json = self._post(
             route=f"/table/{namespace}/{table_name}/insert",
             headers={"Content-Type": content_type},
             data=data,
         )
+        print(result_json)
+        return InsertTableResult.from_dict(result_json)

--- a/dune_client/api/table.py
+++ b/dune_client/api/table.py
@@ -75,7 +75,6 @@ class TableAPI(BaseRouter):
                 "is_private": is_private,
             },
         )
-
         return CreateTableResult.from_dict(result_json)
 
     def insert_table(
@@ -99,5 +98,4 @@ class TableAPI(BaseRouter):
             headers={"Content-Type": content_type},
             data=data,
         )
-        print(result_json)
         return InsertTableResult.from_dict(result_json)

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -357,7 +357,7 @@ class ResultsResponse:
 
 
 @dataclass
-class CreateTableResponse(DataClassJsonMixin):
+class CreateTableResult(DataClassJsonMixin):
     """
     Data type returned by table/create operation
     """

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -11,7 +11,7 @@ from enum import Enum
 from io import BytesIO
 from os import SEEK_END
 from typing import Optional, Any, Union, List, Dict
-
+from dataclasses_json import DataClassJsonMixin
 from dateutil.parser import parse
 
 from dune_client.types import DuneRecord
@@ -354,3 +354,24 @@ class ResultsResponse:
         self.next_uri = other.next_uri
         self.next_offset = other.next_offset
         return self
+
+
+@dataclass
+class CreateTableResponse(DataClassJsonMixin):
+    """
+    Data type returned by table/create operation
+    """
+
+    example_query: str
+    full_name: str
+    namespace: str
+    table_name: str
+
+
+@dataclass
+class InsertTableResult(DataClassJsonMixin):
+    """
+    Data type returned by table/insert operation
+    """
+
+    rows_written: int

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,5 @@
 aiohttp>=3.8.5
+dataclasses-json==0.6.4
 types-python-dateutil>=2.8.19.14
 types-PyYAML>=6.0.12.11
 types-requests>=2.28.0

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -11,6 +11,8 @@ from dune_client.models import (
     ExecutionResponse,
     ExecutionStatusResponse,
     DuneError,
+    InsertTableResult,
+    CreateTableResponse,
 )
 from dune_client.types import QueryParameter
 from dune_client.client import DuneClient
@@ -256,12 +258,14 @@ class TestDuneClient(unittest.TestCase):
                 ],
                 is_private=False,
             ),
-            {
-                "namespace": namespace,
-                "table_name": table_name,
-                "full_name": f"dune.{namespace}.{table_name}",
-                "example_query": f"select * from dune.{namespace}.{table_name} limit 10",
-            },
+            CreateTableResponse.from_dict(
+                {
+                    "namespace": namespace,
+                    "table_name": table_name,
+                    "full_name": f"dune.{namespace}.{table_name}",
+                    "example_query": f"select * from dune.{namespace}.{table_name} limit 10",
+                }
+            ),
         )
 
     @unittest.skip("This is a plus subscription endpoint.")
@@ -277,7 +281,7 @@ class TestDuneClient(unittest.TestCase):
                     data=data,
                     content_type="text/csv",
                 ),
-                {"rows_written": 1},
+                InsertTableResult(rows_written=1),
             )
 
     @unittest.skip("This is a plus subscription endpoint.")
@@ -293,7 +297,7 @@ class TestDuneClient(unittest.TestCase):
                     data=data,
                     content_type="application/x-ndjson",
                 ),
-                {"rows_written": 1},
+                InsertTableResult(rows_written=1),
             )
 
     def test_download_csv_with_pagination(self):

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -127,7 +127,7 @@ class TestDuneClient(unittest.TestCase):
                 {
                     "text_field": "different word",
                     "number_field": 22,
-                    "date_field": "1991-01-01 00:00:000",
+                    "date_field": "1991-01-01 00:00:00.000",
                     "list_field": "Option 2",
                 }
             ],

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -12,7 +12,7 @@ from dune_client.models import (
     ExecutionStatusResponse,
     DuneError,
     InsertTableResult,
-    CreateTableResponse,
+    CreateTableResult,
 )
 from dune_client.types import QueryParameter
 from dune_client.client import DuneClient
@@ -127,7 +127,7 @@ class TestDuneClient(unittest.TestCase):
                 {
                     "text_field": "different word",
                     "number_field": 22,
-                    "date_field": "1991-01-01T00:00:00Z",
+                    "date_field": "1991-01-01 00:00:000",
                     "list_field": "Option 2",
                 }
             ],
@@ -258,7 +258,7 @@ class TestDuneClient(unittest.TestCase):
                 ],
                 is_private=False,
             ),
-            CreateTableResponse.from_dict(
+            CreateTableResult.from_dict(
                 {
                     "namespace": namespace,
                     "table_name": table_name,
@@ -354,7 +354,7 @@ class TestDuneClient(unittest.TestCase):
                 {
                     "text_field": "different word",
                     "number_field": 22,
-                    "date_field": "1991-01-01T00:00:00Z",
+                    "date_field": "1991-01-01 00:00:00.000",
                     "list_field": "Option 2",
                 }
             ],
@@ -376,7 +376,7 @@ class TestDuneClient(unittest.TestCase):
             pandas.read_csv(result_csv.data).to_dict(orient="records"),
             [
                 {
-                    "date_field": "2022-05-04T00:00:00Z",
+                    "date_field": "2022-05-04 00:00:00.000",
                     "list_field": "Option 1",
                     "number_field": 3.1415926535,
                     "text_field": "Plain Text",


### PR DESCRIPTION
Following up on a [comment](https://github.com/duneanalytics/dune-client/pull/114#discussion_r1537268614) in #114. This PR introduces a cool new dataclass from dict/json parsing tool. 

Note that we could also replace all the manually implemented "from_dict" methods throughout this project.

The expected way to use this dataclass_json library is as a decorator, but it fails the linter. There is an open issue in their repo related to this: https://github.com/lidatong/dataclasses-json/issues/198#issuecomment-639324501