### PR TITLE
Fix formatting of columns parameter

### DIFF
--- a/dune_client/api/base.py
+++ b/dune_client/api/base.py
@@ -112,13 +112,7 @@ class BaseDuneClient:
 
         params = params or {}
         if columns is not None and len(columns) > 0:
-            output = []
-            for column in columns:
-                # Escape all quotes and add quotes around it
-                col = '"' + column.replace('"', '\\"') + '"'
-                output.append(col)
-
-            params["columns"] = ",".join(output)
+            params["columns"] = ",".join(columns)
         if sample_count is not None:
             params["sample_count"] = sample_count
         if filters is not None:


### PR DESCRIPTION
The current implementation that builds the `columns` parameter wraps each column in double quotes, which is not something the API's parser supports. This leads to errors such as this one:

![image](https://github.com/duneanalytics/dune-client/assets/565238/c3cddffe-463c-421e-a5cb-c4705a42ef78)

We see that doing `curl -H "X-Dune-API-Key:$key" "https://api.dune.com/api/v1/query/3567562/results/csv?columns=donor_fname%2Covertip_amount%2Cdays_overtipped%2Coverall_tip_given_amount%2Coverall_avg_tip_amount&filters=overtip_amount%3E0&sort_by=overall_tip_given_amount%20desc&limit=1"` instead works.