### PR TITLE
fix for adding dataclasses-json on install with pip

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ packages=find:
 platforms = any
 install_requires =
   aiohttp>=3.8.3
+  dataclasses-json==0.6.4
   types-python-dateutil>=2.8.19
   types-PyYAML>=6.0.11
   types-requests>=2.28.0


### PR DESCRIPTION
I run into issues after installing dune-client that dataclasses-json is not installed. I think this should fix it. 