### PR TITLE
Handle `insert_table` errors

### DIFF
--- a/dune_client/api/table.py
+++ b/dune_client/api/table.py
@@ -10,6 +10,7 @@ from dune_client.api.base import BaseRouter
 from dune_client.models import (
     DuneError,
     InsertTableResult,
+    InsertTableErrorResult,
     CreateTableResult,
     DeleteTableResult,
 )
@@ -88,7 +89,7 @@ class TableAPI(BaseRouter):
         table_name: str,
         data: IO[bytes],
         content_type: str,
-    ) -> InsertTableResult:
+    ) -> InsertTableResult | InsertTableErrorResult:
         """
         https://docs.dune.com/api-reference/tables/endpoint/insert
         The insert table endpoint allows you to insert data into an existing table in Dune.
@@ -103,7 +104,11 @@ class TableAPI(BaseRouter):
             headers={"Content-Type": content_type},
             data=data,
         )
-        return InsertTableResult.from_dict(result_json)
+        if "error" in result_json:
+            return InsertTableErrorResult.from_dict(result_json)
+        else:
+            return InsertTableResult.from_dict(result_json)
+        
 
     def delete_table(self, namespace: str, table_name: str) -> DeleteTableResult:
         """

--- a/dune_client/api/table.py
+++ b/dune_client/api/table.py
@@ -10,7 +10,6 @@ from dune_client.api.base import BaseRouter
 from dune_client.models import (
     DuneError,
     InsertTableResult,
-    InsertTableErrorResult,
     CreateTableResult,
     DeleteTableResult,
 )

--- a/dune_client/api/table.py
+++ b/dune_client/api/table.py
@@ -88,7 +88,7 @@ class TableAPI(BaseRouter):
         table_name: str,
         data: IO[bytes],
         content_type: str,
-    ) -> InsertTableResult | InsertTableErrorResult:
+    ) -> InsertTableResult:
         """
         https://docs.dune.com/api-reference/tables/endpoint/insert
         The insert table endpoint allows you to insert data into an existing table in Dune.
@@ -104,7 +104,6 @@ class TableAPI(BaseRouter):
             data=data,
         )
         
-            # return InsertTableErrorResult.from_dict(result_json)
         try:
             return InsertTableResult.from_dict(result_json)
         except KeyError as err:

--- a/dune_client/api/table.py
+++ b/dune_client/api/table.py
@@ -103,7 +103,6 @@ class TableAPI(BaseRouter):
             headers={"Content-Type": content_type},
             data=data,
         )
-        
         try:
             return InsertTableResult.from_dict(result_json)
         except KeyError as err:

--- a/dune_client/api/table.py
+++ b/dune_client/api/table.py
@@ -104,11 +104,12 @@ class TableAPI(BaseRouter):
             headers={"Content-Type": content_type},
             data=data,
         )
-        if "error" in result_json:
-            return InsertTableErrorResult.from_dict(result_json)
-        else:
-            return InsertTableResult.from_dict(result_json)
         
+            # return InsertTableErrorResult.from_dict(result_json)
+        try:
+            return InsertTableResult.from_dict(result_json)
+        except KeyError as err:
+            raise DuneError(result_json, "ResultsResponse", err) from err
 
     def delete_table(self, namespace: str, table_name: str) -> DeleteTableResult:
         """

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -375,6 +375,15 @@ class InsertTableResult(DataClassJsonMixin):
     """
 
     rows_written: int
+    bytes_written: int
+
+@dataclass
+class InsertTableErrorResult(DataClassJsonMixin):
+    """
+    Data type returned by table/insert operation error
+    """
+
+    error: str
 
 
 @dataclass

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -377,14 +377,6 @@ class InsertTableResult(DataClassJsonMixin):
     rows_written: int
     bytes_written: int
 
-@dataclass
-class InsertTableErrorResult(DataClassJsonMixin):
-    """
-    Data type returned by table/insert operation error
-    """
-
-    error: str
-
 
 @dataclass
 class DeleteTableResult(DataClassJsonMixin):


### PR DESCRIPTION
Fix for issue #128 

Attempting to resolve the issue of unhandled insert errors with a new dataclass `InsertTableErrorResult` which can handle the `error` field.

This is most likely not the most elegant way to handle this. I'm open to suggestions :)