### PR TITLE
Reading custom endpoint results SDK support

### DIFF
--- a/dune_client/api/custom.py
+++ b/dune_client/api/custom.py
@@ -32,8 +32,10 @@ class CustomEndpointAPI(BaseRouter):
         sort_by: Optional[List[str]] = None,
     ) -> ResultsResponse:
         """
-        Custom endpoints allow you to fetch and filter data from any custom endpoint you created.
-        More information on Custom Endpoints can be round here: https://docs.dune.com/api-reference/custom/overview
+        Custom endpoints allow you to fetch and filter data from any 
+        custom endpoint you created.
+        More information on Custom Endpoints can be round here: 
+        https://docs.dune.com/api-reference/custom/overview
         
         Args: 
             handle (str): The handle of the team/user.
@@ -61,4 +63,3 @@ class CustomEndpointAPI(BaseRouter):
             return ResultsResponse.from_dict(response_json)
         except KeyError as err:
             raise DuneError(response_json, "ResultsResponse", err) from err
-

--- a/dune_client/api/custom.py
+++ b/dune_client/api/custom.py
@@ -15,7 +15,9 @@ from dune_client.models import (
 
 class CustomEndpointAPI(BaseRouter):
     """
-    
+    Custom endpoints API implementation.
+    Methods:
+        get_custom_endpoint_result(): returns the results of a custom endpoint.
     """
 
     def get_custom_endpoint_result(
@@ -30,7 +32,18 @@ class CustomEndpointAPI(BaseRouter):
         sort_by: Optional[List[str]] = None,
     ) -> ResultsResponse:
         """
+        Custom endpoints allow you to fetch and filter data from any custom endpoint you created.
+        More information on Custom Endpoints can be round here: https://docs.dune.com/api-reference/custom/overview
         
+        Args: 
+            handle (str): The handle of the team/user.
+            endpoint (str): The slug of the custom endpoint.
+            limit (int, optional): The maximum number of results to return.
+            offset (int, optional): The number of results to skip.
+            columns (List[str], optional): A list of columns to return.
+            sample_count (int, optional): The number of results to return.
+            filters (str, optional): The filters to apply.
+            sort_by (List[str], optional): The columns to sort by.
         """
         params = self._build_parameters(
             columns=columns,
@@ -49,4 +62,3 @@ class CustomEndpointAPI(BaseRouter):
         except KeyError as err:
             raise DuneError(response_json, "ResultsResponse", err) from err
 
-   

--- a/dune_client/api/custom.py
+++ b/dune_client/api/custom.py
@@ -12,7 +12,7 @@ from dune_client.models import (
     ResultsResponse,
 )
 
-
+# pylint: disable=duplicate-code
 class CustomEndpointAPI(BaseRouter):
     """
     Custom endpoints API implementation.

--- a/dune_client/api/custom.py
+++ b/dune_client/api/custom.py
@@ -1,0 +1,52 @@
+"""
+Custom endpoints API enables users to
+fetch and filter data from custom endpoints.
+"""
+
+from __future__ import annotations
+from typing import List, Optional
+
+from dune_client.api.base import BaseRouter
+from dune_client.models import (
+    DuneError,
+    ResultsResponse,
+)
+
+
+class CustomEndpointAPI(BaseRouter):
+    """
+    
+    """
+
+    def get_custom_endpoint_result(
+        self,
+        handle: str,
+        endpoint: str,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        columns: Optional[List[str]] = None,
+        sample_count: Optional[int] = None,
+        filters: Optional[str] = None,
+        sort_by: Optional[List[str]] = None,
+    ) -> ResultsResponse:
+        """
+        
+        """
+        params = self._build_parameters(
+            columns=columns,
+            sample_count=sample_count,
+            filters=filters,
+            sort_by=sort_by,
+            limit=limit,
+            offset=offset,
+        )
+        response_json = self._get(
+            route=f"/endpoints/{handle}/{endpoint}/results",
+            params=params,
+        )
+        try:
+            return ResultsResponse.from_dict(response_json)
+        except KeyError as err:
+            raise DuneError(response_json, "ResultsResponse", err) from err
+
+   

--- a/dune_client/api/custom.py
+++ b/dune_client/api/custom.py
@@ -12,6 +12,7 @@ from dune_client.models import (
     ResultsResponse,
 )
 
+
 # pylint: disable=duplicate-code
 class CustomEndpointAPI(BaseRouter):
     """
@@ -32,12 +33,12 @@ class CustomEndpointAPI(BaseRouter):
         sort_by: Optional[List[str]] = None,
     ) -> ResultsResponse:
         """
-        Custom endpoints allow you to fetch and filter data from any 
+        Custom endpoints allow you to fetch and filter data from any
         custom endpoint you created.
-        More information on Custom Endpoints can be round here: 
+        More information on Custom Endpoints can be round here:
         https://docs.dune.com/api-reference/custom/overview
-        
-        Args: 
+
+        Args:
             handle (str): The handle of the team/user.
             endpoint (str): The slug of the custom endpoint.
             limit (int, optional): The maximum number of results to return.

--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -20,6 +20,7 @@ from dune_client.api.base import (
 from dune_client.api.execution import ExecutionAPI
 from dune_client.api.query import QueryAPI
 from dune_client.api.table import TableAPI
+from dune_client.api.custom import CustomEndpointAPI
 from dune_client.models import (
     ResultsResponse,
     DuneError,
@@ -37,7 +38,7 @@ THREE_MONTHS_IN_HOURS = 2191
 POLL_FREQUENCY_SECONDS = 1
 
 
-class ExtendedAPI(ExecutionAPI, QueryAPI, TableAPI):
+class ExtendedAPI(ExecutionAPI, QueryAPI, TableAPI, CustomEndpointAPI):
     """
     Provides higher level helper methods for faster
     and easier development on top of the base ExecutionAPI.

--- a/tests/e2e/test_custom_endpoints.py
+++ b/tests/e2e/test_custom_endpoints.py
@@ -1,0 +1,25 @@
+import copy
+import os
+import time
+import unittest
+
+import dotenv
+
+from dune_client.client import DuneClient
+
+dotenv.load_dotenv()
+
+
+class TestCustomEndpoints(unittest.TestCase):
+    def setUp(self) -> None:
+        self.valid_api_key = os.environ["DUNE_API_KEY"]
+
+    def test_get_execution_status(self):
+        dune = DuneClient(self.valid_api_key)
+        results = dune.get_custom_endpoint_result("dune", "new-test")
+        self.assertEqual(len(results.get_rows()), 10)
+        self.assertEqual(len(results.get_columns()), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_custom_endpoints.py
+++ b/tests/e2e/test_custom_endpoints.py
@@ -19,5 +19,6 @@ class TestCustomEndpoints(unittest.TestCase):
         results = dune.get_custom_endpoint_result("dune", "new-test")
         self.assertEqual(len(results.get_rows()), 10)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/e2e/test_custom_endpoints.py
+++ b/tests/e2e/test_custom_endpoints.py
@@ -14,7 +14,7 @@ class TestCustomEndpoints(unittest.TestCase):
     def setUp(self) -> None:
         self.valid_api_key = os.environ["DUNE_API_KEY"]
 
-    def test_get_execution_status(self):
+    def test_gettin_custom_endpoint_results(self):
         dune = DuneClient(self.valid_api_key)
         results = dune.get_custom_endpoint_result("dune", "new-test")
         self.assertEqual(len(results.get_rows()), 10)

--- a/tests/e2e/test_custom_endpoints.py
+++ b/tests/e2e/test_custom_endpoints.py
@@ -18,8 +18,6 @@ class TestCustomEndpoints(unittest.TestCase):
         dune = DuneClient(self.valid_api_key)
         results = dune.get_custom_endpoint_result("dune", "new-test")
         self.assertEqual(len(results.get_rows()), 10)
-        self.assertEqual(len(results.get_columns()), 5)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This allows for fetching custom-endpoint results. example: 

```
from dune_client.client import DuneClient
dune = DuneClient(api_key='***')
response = dune.get_custom_endpoint_result("<handle>", "<endpoint>", limit = 100)
```

Todo: add some testing