### PR TITLE
Adjustable polling frequency as env variable

### DIFF
--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -2,6 +2,7 @@
 Extended functionality for the ExecutionAPI
 """
 
+import os
 from __future__ import annotations
 
 import logging
@@ -35,7 +36,7 @@ from dune_client.util import age_in_hours
 # This is the expiry time on old query results.
 THREE_MONTHS_IN_HOURS = 2191
 # Seconds between checking execution status
-POLL_FREQUENCY_SECONDS = 1
+POLL_FREQUENCY_SECONDS = os.getenv("POLL_FREQUENCY_SECONDS", 1)
 
 
 class ExtendedAPI(ExecutionAPI, QueryAPI, TableAPI, CustomEndpointAPI):

--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -33,10 +33,13 @@ from dune_client.query import QueryBase, parse_query_object_or_id
 from dune_client.types import QueryParameter
 from dune_client.util import age_in_hours
 
+from dotenv import load_dotenv
+load_dotenv()
+
 # This is the expiry time on old query results.
 THREE_MONTHS_IN_HOURS = 2191
 # Seconds between checking execution status
-POLL_FREQUENCY_SECONDS = os.getenv("POLL_FREQUENCY_SECONDS", 1)
+POLL_FREQUENCY_SECONDS = int(os.getenv("POLL_FREQUENCY_SECONDS", 1))
 
 
 class ExtendedAPI(ExecutionAPI, QueryAPI, TableAPI, CustomEndpointAPI):

--- a/dune_client/api/extensions.py
+++ b/dune_client/api/extensions.py
@@ -2,9 +2,9 @@
 Extended functionality for the ExecutionAPI
 """
 
-import os
 from __future__ import annotations
 
+import os
 import logging
 import time
 


### PR DESCRIPTION
Reason: When using the client, longer queries will exit with a 429 due to a high number of failed attempts to get a result. Allowing the user to define the poll frequency is beneficial if he's aware that he's running a heavier query.

Still defaults to 1 as it currently is.