### PR TITLE
 error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This project's makefile comes equipped with sufficient commands for local develo
 
 ```shell
 make install
-````
+```
 
 ### Format, Lint & Types
 ```shell

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -204,7 +204,7 @@ class TestDuneClient(unittest.TestCase):
             dune.execute_query(query)
         self.assertEqual(
             str(err.exception),
-            "Can't build ExecutionResponse from {'error': 'An internal error occured'}",
+            "Can't build ExecutionResponse from {'error': 'An internal error occurred'}",
         )
 
     def test_invalid_job_id_error(self):


### PR DESCRIPTION
"Occured" is a common misspelling of "occurred"

- "Can't build ExecutionResponse from {'error': 'An internal error occured'}"
+ "Can't build ExecutionResponse from {'error': 'An internal error occurred'}"