### PR TITLE
add cursor rules to use uv and makefile

### DIFF
--- a/.cursor/development.md
+++ b/.cursor/development.md
@@ -1,0 +1,46 @@
+# Development Configuration for Cursor
+
+## Package Manager
+
+Always use `uv` for Python package management in this project.
+
+### Basic uv commands:
+- **Install dependencies**: `uv sync` or `uv install`
+- **Add new packages**: `uv add <package-name>`
+- **Add dev dependencies**: `uv add --dev <package-name>`
+- **Remove packages**: `uv remove <package-name>`
+- **Run scripts**: `uv run <command>`
+
+## Development Workflow
+
+**Use the Makefile for all development tasks.** The project has a comprehensive Makefile that handles testing, linting, formatting, and other development tasks.
+
+### Installation & Setup
+- **Install production dependencies**: `make install`
+- **Install with dev dependencies**: `make install-dev`
+
+### Code Quality & Formatting
+- **Format code**: `make fmt`
+- **Check formatting**: `make fmt-check`
+- **Lint code**: `make lint`
+- **Fix linting issues**: `make lint-fix`
+- **Type checking**: `make types`
+- **Run all checks**: `make check` (formats, lints, and type checks)
+
+### Testing
+- **Run unit tests**: `make test-unit`
+- **Run e2e tests**: `make test-e2e`
+- **Run all tests**: `make test-all`
+- **Run tox tests**: `make test-tox`
+
+### Cleanup
+- **Clean build artifacts**: `make clean`
+
+## Do NOT use directly:
+- `pip install` (use `uv` or Makefile targets)
+- `pytest` directly (use `make test-unit` or `make test-e2e`)
+- `ruff` directly (use `make lint`, `make fmt`, etc.)
+- `mypy` directly (use `make types`)
+
+## Project Structure
+This project uses `uv` for dependency management (see `uv.lock` and `pyproject.toml`) and provides a Makefile for standardized development workflows. Always prefer Makefile targets over running tools directly.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Cursor development guide documenting `uv`-based package management and Makefile-driven workflows.
> 
> - **Docs**:
>   - Add `/.cursor/development.md` outlining development workflow.
>     - Mandates `uv` for Python package management with key commands.
>     - Standardizes using Makefile targets for install, formatting, linting, typing, testing, and cleanup.
>     - Lists prohibited direct tool usage (`pip install`, `pytest`, `ruff`, `mypy`).
>     - Notes project structure and reliance on `uv.lock` and `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51726ab6defcdadcdd6085deff21db1f24708c5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->