### PR TITLE
Simplify async client

### DIFF
--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -1,5 +1,5 @@
 """
-Simplified Async Dune Client - A thin async wrapper around the sync client logic
+Async Dune Client - A thin async wrapper around the sync client logic
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ from dune_client.query import QueryBase, parse_query_object_or_id
 
 class AsyncDuneClient(BaseDuneClient):
     """
-    A simplified asynchronous interface for Dune API.
+    An asynchronous interface for Dune API.
     Reuses the sync client's logic for parameter validation and building.
     """
 
@@ -46,7 +46,7 @@ class AsyncDuneClient(BaseDuneClient):
         self._session: ClientSession | None = None
 
     async def __aenter__(self) -> Self:
-        # Simple session creation
+        # Create session with timeout
         timeout = ClientTimeout(total=self.request_timeout)
         self._session = ClientSession(
             base_url=self.base_url,

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -1,28 +1,14 @@
-""" "
-Async Dune Client Class responsible for refreshing Dune Queries
-Framework built on Dune's API Documentation
-https://docs.dune.com/api-reference/overview/introduction
+"""
+Simplified Async Dune Client - A thin async wrapper around the sync client logic
 """
 
 from __future__ import annotations
 
 import asyncio
-import ssl
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-import certifi
-from aiohttp import (
-    ClientResponse,
-    ClientResponseError,
-    ClientSession,
-    ClientTimeout,
-    ContentTypeError,
-    TCPConnector,
-)
+from aiohttp import ClientSession, ClientTimeout
 
 from dune_client.api.base import (
     DUNE_CSV_NEXT_OFFSET_HEADER,
@@ -42,36 +28,11 @@ from dune_client.models import (
 from dune_client.query import QueryBase, parse_query_object_or_id
 
 
-class RetryableError(Exception):
-    """
-    Internal exception used to signal that the request should be retried
-    """
-
-    def __init__(self, base_error: ClientResponseError) -> None:
-        self.base_error = base_error
-
-
-class MaxRetryError(Exception):
-    """
-    This exception is raised when the maximum number of retries is exceeded,
-    e.g. due to rate limiting or internal server errors
-    """
-
-    def __init__(self, url: str, reason: Exception | None = None) -> None:
-        self.reason = reason
-
-        message = f"Max retries exceeded with url: {url} (Caused by {reason!r})"
-
-        super().__init__(message)
-
-
 class AsyncDuneClient(BaseDuneClient):
     """
-    An asynchronous interface for Dune API with a few convenience methods
-    combining the use of endpoints (e.g. refresh)
+    A simplified asynchronous interface for Dune API.
+    Reuses the sync client's logic for parameter validation and building.
     """
-
-    _connection_limit = 3
 
     def __init__(
         self,
@@ -80,147 +41,72 @@ class AsyncDuneClient(BaseDuneClient):
         request_timeout: float | None = None,
         client_version: str = "v1",
         performance: str = "medium",
-        connection_limit: int = 3,
     ):
-        """
-        api_key - Dune API key
-        connection_limit - number of parallel requests to execute.
-        For non-pro accounts Dune allows only up to 3 requests but that number can be increased.
-        """
         super().__init__(api_key, base_url, request_timeout, client_version, performance)
-        self._connection_limit = connection_limit
         self._session: ClientSession | None = None
 
-    async def _create_session(self) -> ClientSession:
-        # Create an SSL context using the certifi certificate store
-        ssl_context = ssl.create_default_context(cafile=certifi.where())
-
-        conn = TCPConnector(limit=self._connection_limit, ssl=ssl_context)
-        return ClientSession(
-            connector=conn,
-            base_url=self.base_url,
-            timeout=ClientTimeout(total=self.request_timeout),
-        )
-
-    async def connect(self) -> None:
-        """Opens a client session (can be used instead of async with)"""
-        self._session = await self._create_session()
-
-    async def disconnect(self) -> None:
-        """Closes client session"""
-        if self._session:
-            await self._session.close()
-
     async def __aenter__(self) -> Self:
-        self._session = await self._create_session()
+        # Simple session creation
+        timeout = ClientTimeout(total=self.request_timeout)
+        self._session = ClientSession(
+            base_url=self.base_url,
+            timeout=timeout,
+        )
         return self
 
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object
     ) -> None:
-        await self.disconnect()
+        if self._session:
+            await self._session.close()
 
-    async def _handle_response(self, response: ClientResponse) -> Any:
-        if response.status in {429, 502, 503, 504}:
-            try:
-                response.raise_for_status()
-            except ClientResponseError as err:
-                raise RetryableError(
-                    base_error=err,
-                ) from err
-        try:
-            # Some responses can be decoded and converted to DuneErrors
-            response_json = await response.json()
-            self.logger.debug(f"received response {response_json}")
-        except ContentTypeError as err:
-            # Others can't. Only raise HTTP error for not decodable errors
-            response.raise_for_status()
-            raise ValueError("Unreachable since previous line raises") from err
-        else:
-            return response_json
-
-    def _route_url(
+    async def _request(
         self,
+        method: str,
         route: str | None = None,
         url: str | None = None,
-    ) -> str:
-        if route is not None:
-            final_route = f"{self.api_version}{route}"
-        elif url is not None:
-            assert url.startswith(self.base_url)
-            final_route = url[len(self.base_url) :]
-        else:
-            assert route is not None or url is not None
-
-        return final_route
-
-    async def _handle_ratelimit(self, call: Callable[..., Any], url: str) -> Any:
-        """Generic wrapper around request callables. If the request fails due to rate limiting,
-        or server side errors, it will retry it up to five times, sleeping i * 5s in between
-        """
-        backoff_factor = 0.5
-        error: ClientResponseError | None = None
-        for i in range(5):
-            try:
-                return await call()
-            except RetryableError as e:
-                self.logger.warning(
-                    f"Rate limited or internal error. Retrying in {i * 5} seconds..."
-                )
-                error = e.base_error
-                await asyncio.sleep(i**2 * backoff_factor)
-
-        raise MaxRetryError(url, error)
-
-    async def _get(
-        self,
-        route: str | None = None,
+        json: Any | None = None,
         params: Any | None = None,
         raw: bool = False,
-        url: str | None = None,
     ) -> Any:
-        final_route = self._route_url(route=route, url=url)
-        self.logger.debug(f"GET received input route={final_route}")
+        """Unified request method that handles all HTTP methods"""
+        if self._session is None:
+            raise ValueError("Client is not connected; use 'async with AsyncDuneClient()'")
 
-        async def _get() -> Any:
-            if self._session is None:
-                raise ValueError("Client is not connected; call `await cl.connect()`")
-            response = await self._session.get(
-                url=final_route,
-                headers=self.default_headers(),
-                params=params,
-            )
+        # Handle both route and full URL
+        if url is not None:
+            # If it's a full URL, extract the path part for use with base_url session
+            final_url = url.removeprefix(self.base_url)
+        elif route is not None:
+            final_url = f"{self.api_version}{route}"
+        else:
+            raise ValueError("Either route or url must be provided")
+
+        async with self._session.request(
+            method=method,
+            url=final_url,
+            json=json,
+            params=params,
+            headers=self.default_headers(),
+        ) as response:
             if raw:
                 return response
-            return await self._handle_response(response)
 
-        return await self._handle_ratelimit(_get, final_route)
-
-    async def _post(self, route: str, params: Any) -> Any:
-        url = self._route_url(route)
-        self.logger.debug(f"POST received input url={url}, params={params}")
-
-        async def _post() -> Any:
-            if self._session is None:
-                raise ValueError("Client is not connected; call `await cl.connect()`")
-            response = await self._session.post(
-                url=url,
-                json=params,
-                headers=self.default_headers(),
-            )
-            return await self._handle_response(response)
-
-        return await self._handle_ratelimit(_post, route)
+            response.raise_for_status()
+            response_json = await response.json()
+            self.logger.debug(f"received response {response_json}")
+            return response_json
 
     async def execute(self, query: QueryBase, performance: str | None = None) -> ExecutionResponse:
-        """Post's to Dune API for execute `query`"""
+        """Execute a query"""
         params = query.request_format()
         params["performance"] = performance or self.performance
 
         self.logger.info(f"executing {query.query_id} on {performance or self.performance} cluster")
-        response_json = await self._post(
+        response_json = await self._request(
+            "POST",
             route=f"/query/{query.query_id}/execute",
-            params=params,
+            json=params,
         )
         try:
             return ExecutionResponse.from_dict(response_json)
@@ -228,8 +114,8 @@ class AsyncDuneClient(BaseDuneClient):
             raise DuneError(response_json, "ExecutionResponse", err) from err
 
     async def get_status(self, job_id: str) -> ExecutionStatusResponse:
-        """GET status from Dune API for `job_id` (aka `execution_id`)"""
-        response_json = await self._get(route=f"/execution/{job_id}/status")
+        """Get execution status"""
+        response_json = await self._request("GET", route=f"/execution/{job_id}/status")
         try:
             return ExecutionStatusResponse.from_dict(response_json)
         except KeyError as err:
@@ -244,30 +130,35 @@ class AsyncDuneClient(BaseDuneClient):
         filters: str | None = None,
         sort_by: list[str] | None = None,
     ) -> ResultsResponse:
-        """GET results from Dune API for `job_id` (aka `execution_id`)"""
-        assert (
-            # We are not sampling
-            sample_count is None
-            # We are sampling and don't use filters or pagination
-            or (batch_size is None and filters is None)
-        ), "sampling cannot be combined with filters or pagination"
-
-        if sample_count is None and batch_size is None:
-            batch_size = MAX_NUM_ROWS_PER_BATCH
-
-        results = await self._get_result_page(
-            job_id,
+        """Get execution results with pagination"""
+        # Reuse parameter validation from base class
+        params = self._build_parameters(
             columns=columns,
             sample_count=sample_count,
             filters=filters,
             sort_by=sort_by,
-            limit=batch_size,
+            limit=batch_size or MAX_NUM_ROWS_PER_BATCH,
+            offset=0,
         )
-        while results.next_uri is not None:
-            batch = await self._get_result_by_url(results.next_uri)
-            results += batch
 
-        return results
+        response_json = await self._request(
+            "GET",
+            route=f"/execution/{job_id}/results",
+            params=params,
+        )
+
+        try:
+            results = ResultsResponse.from_dict(response_json)
+        except KeyError as err:
+            raise DuneError(response_json, "ResultsResponse", err) from err
+        else:
+            # Handle pagination
+            while results.next_uri:
+                response_json = await self._request("GET", url=results.next_uri)
+                batch = ResultsResponse.from_dict(response_json)
+                results += batch
+
+            return results
 
     async def get_result_csv(
         self,
@@ -278,87 +169,86 @@ class AsyncDuneClient(BaseDuneClient):
         filters: str | None = None,
         sort_by: list[str] | None = None,
     ) -> ExecutionResultCSV:
-        """
-        GET results in CSV format from Dune API for `job_id` (aka `execution_id`)
-
-        this API only returns the raw data in CSV format, it is faster & lighterweight
-        use this method for large results where you want lower CPU and memory overhead
-        if you need metadata information use get_results() or get_status()
-        """
-        assert (
-            # We are not sampling
-            sample_count is None
-            # We are sampling and don't use filters or pagination
-            or (batch_size is None and filters is None)
-        ), "sampling cannot be combined with filters or pagination"
-
-        if sample_count is None and batch_size is None:
-            batch_size = MAX_NUM_ROWS_PER_BATCH
-
-        results = await self._get_result_csv_page(
-            job_id,
+        """Get execution results in CSV format with pagination"""
+        params = self._build_parameters(
             columns=columns,
             sample_count=sample_count,
             filters=filters,
             sort_by=sort_by,
-            limit=batch_size,
+            limit=batch_size or MAX_NUM_ROWS_PER_BATCH,
+            offset=0,
         )
-        while results.next_uri is not None:
-            batch = await self._get_result_csv_by_url(results.next_uri)
-            results += batch
 
-        return results
+        # First request
+        async with self._session.get(
+            f"{self.api_version}/execution/{job_id}/results/csv",
+            params=params,
+            headers=self.default_headers(),
+        ) as response:
+            response.raise_for_status()
+            data = BytesIO(await response.read())
+            next_uri = response.headers.get(DUNE_CSV_NEXT_URI_HEADER)
+            next_offset = response.headers.get(DUNE_CSV_NEXT_OFFSET_HEADER)
+
+        result = ExecutionResultCSV(data=data, next_uri=next_uri, next_offset=next_offset)
+
+        # Handle pagination
+        while result.next_uri:
+            # Extract path from full URL for use with base_url session
+            next_path = result.next_uri.removeprefix(self.base_url)
+            async with self._session.get(
+                next_path,
+                headers=self.default_headers(),
+            ) as response:
+                response.raise_for_status()
+                batch_data = BytesIO(await response.read())
+                next_uri = response.headers.get(DUNE_CSV_NEXT_URI_HEADER)
+                next_offset = response.headers.get(DUNE_CSV_NEXT_OFFSET_HEADER)
+
+            batch = ExecutionResultCSV(data=batch_data, next_uri=next_uri, next_offset=next_offset)
+            result += batch
+
+        return result
 
     async def get_latest_result(
         self,
         query: QueryBase | str | int,
         batch_size: int = MAX_NUM_ROWS_PER_BATCH,
     ) -> ResultsResponse:
-        """
-        GET the latest results for a query_id without having to execute the query again.
-
-        :param query: :class:`Query` object OR query id as string | int
-
-        https://docs.dune.com/api-reference/executions/endpoint/get-query-result
-        """
+        """Get the latest results for a query without re-executing"""
         params, query_id = parse_query_object_or_id(query)
-
         if params is None:
             params = {}
-
         params["limit"] = batch_size
 
-        response_json = await self._get(
+        response_json = await self._request(
+            "GET",
             route=f"/query/{query_id}/results",
             params=params,
         )
+
         try:
             results = ResultsResponse.from_dict(response_json)
-            while results.next_uri is not None:
-                batch = await self._get_result_by_url(results.next_uri)
-                results += batch
         except KeyError as err:
             raise DuneError(response_json, "ResultsResponse", err) from err
         else:
+            # Handle pagination
+            while results.next_uri:
+                response_json = await self._request("GET", url=results.next_uri)
+                batch = ResultsResponse.from_dict(response_json)
+                results += batch
+
             return results
 
     async def cancel_execution(self, job_id: str) -> bool:
-        """POST Execution Cancellation to Dune API for `job_id` (aka `execution_id`)"""
-        response_json = await self._post(
-            route=f"/execution/{job_id}/cancel",
-            params=None,
-        )
+        """Cancel an execution"""
+        response_json = await self._request("POST", route=f"/execution/{job_id}/cancel")
         try:
-            # No need to make a dataclass for this since it's just a boolean.
-            success: bool = response_json["success"]
+            return response_json["success"]
         except KeyError as err:
             raise DuneError(response_json, "CancellationResponse", err) from err
-        else:
-            return success
 
-    ########################
-    # Higher level functions
-    ########################
+    # High-level convenience methods
 
     async def refresh(
         self,
@@ -371,26 +261,27 @@ class AsyncDuneClient(BaseDuneClient):
         filters: str | None = None,
         sort_by: list[str] | None = None,
     ) -> ResultsResponse:
-        """
-        Executes a Dune `query`, waits until execution completes,
-        fetches and returns the results.
-        Sleeps `ping_frequency` seconds between each status request.
-        """
-        assert (
-            # We are not sampling
-            sample_count is None
-            # We are sampling and don't use filters or pagination
-            or (batch_size is None and filters is None)
-        ), "sampling cannot be combined with filters or pagination"
+        """Execute a query and wait for results"""
+        job_id = (await self.execute(query, performance)).execution_id
 
-        job_id = await self._refresh(query, ping_frequency=ping_frequency, performance=performance)
+        # Wait for completion
+        status = await self.get_status(job_id)
+        while status.state not in ExecutionState.terminal_states():
+            self.logger.info(f"waiting for query execution {job_id} to complete: {status}")
+            await asyncio.sleep(ping_frequency)
+            status = await self.get_status(job_id)
+
+        if status.state == ExecutionState.FAILED:
+            self.logger.error(status)
+            raise QueryFailedError(f"Error data: {status.error}")
+
         return await self.get_result(
             job_id,
+            batch_size=batch_size,
             columns=columns,
             sample_count=sample_count,
             filters=filters,
             sort_by=sort_by,
-            batch_size=batch_size,
         )
 
     async def refresh_csv(
@@ -404,26 +295,27 @@ class AsyncDuneClient(BaseDuneClient):
         filters: str | None = None,
         sort_by: list[str] | None = None,
     ) -> ExecutionResultCSV:
-        """
-        Executes a Dune query, waits till execution completes,
-        fetches and the results in CSV format
-        (use it load the data directly in pandas.from_csv() or similar frameworks)
-        """
-        assert (
-            # We are not sampling
-            sample_count is None
-            # We are sampling and don't use filters or pagination
-            or (batch_size is None and filters is None)
-        ), "sampling cannot be combined with filters or pagination"
+        """Execute a query and get results in CSV format"""
+        job_id = (await self.execute(query, performance)).execution_id
 
-        job_id = await self._refresh(query, ping_frequency=ping_frequency, performance=performance)
+        # Wait for completion
+        status = await self.get_status(job_id)
+        while status.state not in ExecutionState.terminal_states():
+            self.logger.info(f"waiting for query execution {job_id} to complete: {status}")
+            await asyncio.sleep(ping_frequency)
+            status = await self.get_status(job_id)
+
+        if status.state == ExecutionState.FAILED:
+            self.logger.error(status)
+            raise QueryFailedError(f"Error data: {status.error}")
+
         return await self.get_result_csv(
             job_id,
+            batch_size=batch_size,
             columns=columns,
             sample_count=sample_count,
             filters=filters,
             sort_by=sort_by,
-            batch_size=batch_size,
         )
 
     async def refresh_into_dataframe(
@@ -436,158 +328,34 @@ class AsyncDuneClient(BaseDuneClient):
         filters: str | None = None,
         sort_by: list[str] | None = None,
     ) -> Any:
-        """
-        Execute a Dune Query, waits till execution completes,
-        fetched and returns the result as a Pandas DataFrame
-
-        This is a convenience method that uses refresh_csv underneath
-        """
+        """Execute a query and return results as a pandas DataFrame"""
         try:
             import pandas as pd  # noqa: PLC0415
         except ImportError as exc:
             raise ImportError("dependency failure, pandas is required but missing") from exc
+
         results = await self.refresh_csv(
             query,
             performance=performance,
+            batch_size=batch_size,
             columns=columns,
             sample_count=sample_count,
             filters=filters,
             sort_by=sort_by,
-            batch_size=batch_size,
         )
         return pd.read_csv(results.data)
 
-    #################
-    # Private Methods
-    #################
+    # For backwards compatibility
+    async def connect(self) -> None:
+        """Opens a client session (can be used instead of async with)"""
+        if self._session is None:
+            timeout = ClientTimeout(total=self.request_timeout)
+            self._session = ClientSession(
+                base_url=self.base_url,
+                timeout=timeout,
+            )
 
-    async def _get_result_page(
-        self,
-        job_id: str,
-        limit: int | None = None,
-        offset: int | None = None,
-        columns: list[str] | None = None,
-        sample_count: int | None = None,
-        filters: str | None = None,
-        sort_by: list[str] | None = None,
-    ) -> ResultsResponse:
-        """GET a page of results from Dune API for `job_id` (aka `execution_id`)"""
-
-        if sample_count is None and limit is None and offset is None:
-            limit = MAX_NUM_ROWS_PER_BATCH
-            offset = 0
-
-        params = self._build_parameters(
-            columns=columns,
-            sample_count=sample_count,
-            filters=filters,
-            sort_by=sort_by,
-            limit=limit,
-            offset=offset,
-        )
-        response_json = await self._get(
-            route=f"/execution/{job_id}/results",
-            params=params,
-        )
-
-        try:
-            return ResultsResponse.from_dict(response_json)
-        except KeyError as err:
-            raise DuneError(response_json, "ResultsResponse", err) from err
-
-    async def _get_result_by_url(
-        self,
-        url: str,
-        params: dict[str, Any] | None = None,
-    ) -> ResultsResponse:
-        """
-        GET results from Dune API with a given URL. This is particularly useful for pagination.
-        """
-        response_json = await self._get(url=url, params=params)
-
-        try:
-            return ResultsResponse.from_dict(response_json)
-        except KeyError as err:
-            raise DuneError(response_json, "ResultsResponse", err) from err
-
-    async def _get_result_csv_page(
-        self,
-        job_id: str,
-        limit: int | None = None,
-        offset: int | None = None,
-        columns: list[str] | None = None,
-        sample_count: int | None = None,
-        filters: str | None = None,
-        sort_by: list[str] | None = None,
-    ) -> ExecutionResultCSV:
-        """
-        GET a page of results in CSV format from Dune API for `job_id` (aka `execution_id`)
-        """
-
-        if sample_count is None and limit is None and offset is None:
-            limit = MAX_NUM_ROWS_PER_BATCH
-            offset = 0
-
-        params = self._build_parameters(
-            columns=columns,
-            sample_count=sample_count,
-            filters=filters,
-            sort_by=sort_by,
-            limit=limit,
-            offset=offset,
-        )
-
-        route = f"/execution/{job_id}/results/csv"
-        response = await self._get(route=route, params=params, raw=True)
-        response.raise_for_status()
-
-        next_uri = response.headers.get(DUNE_CSV_NEXT_URI_HEADER)
-        next_offset = response.headers.get(DUNE_CSV_NEXT_OFFSET_HEADER)
-        return ExecutionResultCSV(
-            data=BytesIO(await response.content.read(-1)),
-            next_uri=next_uri,
-            next_offset=next_offset,
-        )
-
-    async def _get_result_csv_by_url(
-        self,
-        url: str,
-        params: dict[str, Any] | None = None,
-    ) -> ExecutionResultCSV:
-        """
-        GET results in CSV format from Dune API with a given URL.
-        This is particularly useful for pagination.
-        """
-        response = await self._get(url=url, params=params, raw=True)
-        response.raise_for_status()
-
-        next_uri = response.headers.get(DUNE_CSV_NEXT_URI_HEADER)
-        next_offset = response.headers.get(DUNE_CSV_NEXT_OFFSET_HEADER)
-        return ExecutionResultCSV(
-            data=BytesIO(await response.content.read(-1)),
-            next_uri=next_uri,
-            next_offset=next_offset,
-        )
-
-    async def _refresh(
-        self,
-        query: QueryBase,
-        ping_frequency: int = 5,
-        performance: str | None = None,
-    ) -> str:
-        """
-        Executes a Dune `query`, waits until execution completes,
-        fetches and returns the results.
-        Sleeps `ping_frequency` seconds between each status request.
-        """
-        job_id = (await self.execute(query=query, performance=performance)).execution_id
-        status = await self.get_status(job_id)
-        while status.state not in ExecutionState.terminal_states():
-            self.logger.info(f"waiting for query execution {job_id} to complete: {status}")
-            await asyncio.sleep(ping_frequency)
-            status = await self.get_status(job_id)
-        if status.state == ExecutionState.FAILED:
-            self.logger.error(status)
-            raise QueryFailedError(f"Error data: {status.error}")
-
-        return job_id
+    async def disconnect(self) -> None:
+        """Closes client session"""
+        if self._session:
+            await self._session.close()

--- a/tests/e2e/test_async_client.py
+++ b/tests/e2e/test_async_client.py
@@ -4,6 +4,7 @@ import aiounittest
 import pandas as pd
 
 from dune_client.client_async import AsyncDuneClient
+from dune_client.models import ExecutionState
 from dune_client.query import QueryBase
 
 
@@ -85,7 +86,6 @@ class TestDuneClient(aiounittest.AsyncTestCase):
             {"number": 2},
         ]
 
-    @unittest.skip("Large performance tier doesn't currently work.")
     async def test_refresh_context_manager_performance_large(self):
         async with AsyncDuneClient() as cl:
             results = (await cl.refresh(self.query, performance="large")).get_rows()
@@ -100,6 +100,59 @@ class TestDuneClient(aiounittest.AsyncTestCase):
         async with AsyncDuneClient() as cl:
             results = (await cl.get_latest_result(self.query.query_id)).get_rows()
         assert len(results) > 0
+
+    async def test_execute(self):
+        async with AsyncDuneClient() as cl:
+            execution_response = await cl.execute(self.query)
+            assert execution_response.execution_id is not None
+            assert execution_response.state in [ExecutionState.EXECUTING, ExecutionState.PENDING, ExecutionState.COMPLETED]
+
+    async def test_get_status(self):
+        async with AsyncDuneClient() as cl:
+            # First execute a query to get a job ID
+            execution_response = await cl.execute(self.query)
+            job_id = execution_response.execution_id
+            
+            # Then get its status
+            status = await cl.get_status(job_id)
+            assert status.execution_id == job_id
+            assert status.state is not None
+
+    async def test_get_result(self):
+        async with AsyncDuneClient() as cl:
+            # Execute and wait for completion using refresh
+            results = await cl.refresh(self.query)
+            job_id = results.execution_id
+            
+            # Now get results directly
+            direct_results = await cl.get_result(job_id)
+            assert direct_results.execution_id == job_id
+            assert len(direct_results.get_rows()) > 0
+
+    async def test_get_result_csv(self):
+        async with AsyncDuneClient() as cl:
+            # Execute and wait for completion using refresh
+            results = await cl.refresh(self.query)
+            job_id = results.execution_id
+            
+            # Now get CSV results directly
+            csv_results = await cl.get_result_csv(job_id)
+            assert csv_results.data is not None
+            # Verify we can read the CSV
+            import pandas as pd
+            df = pd.read_csv(csv_results.data)
+            assert len(df) > 0
+
+    async def test_cancel_execution(self):
+        async with AsyncDuneClient() as cl:
+            # Execute a query
+            execution_response = await cl.execute(self.query)
+            job_id = execution_response.execution_id
+            
+            # Try to cancel it (might already be completed, but that's ok)
+            success = await cl.cancel_execution(job_id)
+            # success can be True or False depending on timing
+            assert isinstance(success, bool)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_async_client.py
+++ b/tests/e2e/test_async_client.py
@@ -105,14 +105,18 @@ class TestDuneClient(aiounittest.AsyncTestCase):
         async with AsyncDuneClient() as cl:
             execution_response = await cl.execute(self.query)
             assert execution_response.execution_id is not None
-            assert execution_response.state in [ExecutionState.EXECUTING, ExecutionState.PENDING, ExecutionState.COMPLETED]
+            assert execution_response.state in [
+                ExecutionState.EXECUTING,
+                ExecutionState.PENDING,
+                ExecutionState.COMPLETED,
+            ]
 
     async def test_get_status(self):
         async with AsyncDuneClient() as cl:
             # First execute a query to get a job ID
             execution_response = await cl.execute(self.query)
             job_id = execution_response.execution_id
-            
+
             # Then get its status
             status = await cl.get_status(job_id)
             assert status.execution_id == job_id
@@ -123,7 +127,7 @@ class TestDuneClient(aiounittest.AsyncTestCase):
             # Execute and wait for completion using refresh
             results = await cl.refresh(self.query)
             job_id = results.execution_id
-            
+
             # Now get results directly
             direct_results = await cl.get_result(job_id)
             assert direct_results.execution_id == job_id
@@ -134,12 +138,13 @@ class TestDuneClient(aiounittest.AsyncTestCase):
             # Execute and wait for completion using refresh
             results = await cl.refresh(self.query)
             job_id = results.execution_id
-            
+
             # Now get CSV results directly
             csv_results = await cl.get_result_csv(job_id)
             assert csv_results.data is not None
             # Verify we can read the CSV
             import pandas as pd
+
             df = pd.read_csv(csv_results.data)
             assert len(df) > 0
 
@@ -148,7 +153,7 @@ class TestDuneClient(aiounittest.AsyncTestCase):
             # Execute a query
             execution_response = await cl.execute(self.query)
             job_id = execution_response.execution_id
-            
+
             # Try to cancel it (might already be completed, but that's ok)
             success = await cl.cancel_execution(job_id)
             # success can be True or False depending on timing


### PR DESCRIPTION
This PR rewrites the async client to be a more minimal wrapper around the sync client and increases test coverage somewhat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites AsyncDuneClient as a thin wrapper over the sync client with a unified request path and streamlined pagination, and adds comprehensive e2e tests for core operations.
> 
> - **Async client (`dune_client/client_async.py`)**:
>   - **Rewrite**: Make `AsyncDuneClient` a thin async wrapper reusing sync-client parameter building/logic.
>   - **Requests**: Replace `_get`/`_post`/retry logic with a single `_request` method; drop custom SSL/TCPConnector and rate-limit retry handling.
>   - **Session mgmt**: Create session in `__aenter__`; keep `connect`/`disconnect` for backward compatibility.
>   - **Results**: Use `_build_parameters`; inline pagination for JSON (`/results`) and CSV (`/results/csv`) using `next_uri` headers/fields; support full-URL pagination via base-url-relative paths.
>   - **Refresh**: Simplify `refresh`/`refresh_csv` to `execute` + status polling; raise `QueryFailedError` on failure.
> - **Tests (`tests/e2e/test_async_client.py`)**:
>   - Add tests for `execute`, `get_status`, `get_result`, `get_result_csv`, and `cancel_execution`.
>   - Update existing tests to align with new pagination and session handling; enable previously skipped large-performance test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feff9fcea3cbbb0f554bf5993327013723dcbe80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->