### PR TITLE
Not the library's job to configure logger

### DIFF
--- a/dune_client/api/base.py
+++ b/dune_client/api/base.py
@@ -52,7 +52,6 @@ class BaseDuneClient:
         self.client_version = client_version
         self.performance = performance
         self.logger = logging.getLogger(__name__)
-        logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")
         retry_strategy = Retry(
             total=5,
             backoff_factor=0.5,

--- a/dune_client/file/base.py
+++ b/dune_client/file/base.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from dune_client.types import DuneRecord
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")
 
 
 class FileRWInterface(ABC):

--- a/dune_client/file/interface.py
+++ b/dune_client/file/interface.py
@@ -10,7 +10,6 @@ from dune_client.file.base import CSVFile, FileRWInterface, JSONFile, NDJSONFile
 from dune_client.types import DuneRecord
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")
 
 
 class FileIO:

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from dune_client.types import DuneRecord
 
 log = logging.getLogger(__name__)
-logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s", level=logging.INFO)
 
 
 class QueryFailedError(Exception):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes all `logging.basicConfig(...)` calls from library modules to avoid configuring logging in user applications.
> 
> - **Logging**:
>   - Remove `logging.basicConfig(...)` from `dune_client/api/base.py`, `dune_client/file/base.py`, `dune_client/file/interface.py`, and `dune_client/models.py` to stop configuring logging within the library.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638998b56abcc919d04143aae514aa56ea682854. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->