### PR TITLE
Add uv exclude-newer cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dev = [
     "aiounittest>=1.4.2",
 ]
 
+[tool.uv]
+exclude-newer = "3 days"
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
Add uv `exclude-newer = "3 days"` dependency cooldown to `[tool.uv]` and refresh `uv.lock`.

Made with [Cursor](https://cursor.com)