### PR TITLE
Add uv no-build (binary-only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,9 @@ dev = [
 [tool.uv]
 exclude-newer = "3 days"
 no-build = true
-no-build-package = { dune-client = false }
+# binary-only, except allow this package to build from source (dynamic hatch-vcs
+# version requires a build to resolve metadata); third-party stays wheels-only
+no-binary-package = ["dune-client"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dev = [
 
 [tool.uv]
 exclude-newer = "3 days"
+no-build = true
+no-build-package = { dune-client = false }
 
 [tool.hatch.version]
 source = "vcs"

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P3D"
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
Add uv `no-build = true` (binary-only) to enforce wheels-only installs. The package itself is exempted via `no-build-package` so the editable build still works; third-party source builds stay blocked.

Made with [Cursor](https://cursor.com)