### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for dune-client
+# Owners are automatically requested for review on PRs touching matched paths.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @bh2smith


### PR DESCRIPTION
## What

Adds a `.github/CODEOWNERS` file assigning `@bh2smith` as the default owner for all paths.

## Why

Brings ownership parity with the other Dune API client SDKs and ensures reviewers are auto-requested on PRs. Mirrors the same change being made across the TS and Rust client repos.

Adjust the owner(s) if a team handle (e.g. a `@duneanalytics/...` team) is preferred.